### PR TITLE
Add more flexibility in searching for items

### DIFF
--- a/data/duke.txt
+++ b/data/duke.txt
@@ -11,3 +11,4 @@ D | 0 | return book | 2019-12-02 1800
 E | 0 | project meeting | Mon 2pm - 4pm
 E | 0 | deathhh | Wed 10am - 10pm
 D | 0 | ip | 2024-02-21 2359
+T | 0 | knif

--- a/src/main/java/duke/Parser.java
+++ b/src/main/java/duke/Parser.java
@@ -46,11 +46,47 @@ public class Parser {
             LocalDate dateToCheck = LocalDate.parse(dateStr, dateFormatter);
             return ui.showDeadlinesEventsOnDate(TaskList.getTasks(), TaskList.getTaskNum(), dateToCheck);
         case "find":
-            assert position != -1 && position + 1 < userInput.length() : "Invalid position";
-            String keyword = userInput.substring(position + 1);
-            return ui.showMatchingTasks(keyword);
+            return handleFind(userInput, ui, position);
         default:
             throw new DukeException("     Gurl I'm sorry, idk what that means :-(");
+        }
+    }
+
+    /**
+     * Handles the find command.
+     * @param userInput The user input.
+     * @param ui The user interface.
+     * @param position The position of the command in the user input.
+     * @return The response to the user input.
+     */
+    private static String handleFind(String userInput, Ui ui, int position) {
+        assert position != -1 && position + 1 < userInput.length() : "Invalid position";
+        String keyword = userInput.substring(position + 1).trim().toLowerCase();
+
+        // Ensure the keyword has at least two characters
+        if (keyword.length() < 2) {
+            return "     Please provide a keyword with at least two characters.";
+        }
+
+        StringBuilder matchingTasks = new StringBuilder();
+        int count = 0;
+
+        // Iterate through tasks to find matching ones
+        for (int i = 0; i < TaskList.getTaskNum(); i++) {
+            Task task = TaskList.getTask(i);
+            String taskDescription = task.toString();
+
+            // Check if task description contains the keyword
+            if (taskDescription.toLowerCase().contains(keyword)) {
+                count++;
+                matchingTasks.append(count).append(". ").append(task).append("\n");
+            }
+        }
+
+        if (count == 0) {
+            return "     No matching tasks found.";
+        } else {
+            return ui.showMatchingTasks(matchingTasks.toString());
         }
     }
 

--- a/src/main/java/duke/Ui.java
+++ b/src/main/java/duke/Ui.java
@@ -124,16 +124,10 @@ public class Ui {
      * @param matchingTasks The matching tasks.
      * @return The matching tasks.
      */
-    public String showMatchingTasks(String... matchingTasks) {
+    public String showMatchingTasks(String matchingTasks) {
         StringBuilder result = new StringBuilder();
         result.append("     Here are the matching tasks in your list:\n");
-        if (matchingTasks.length == 0) {
-            result.append("     No matching tasks found.\n");
-        } else {
-            for (int i = 0; i < matchingTasks.length; i++) {
-                result.append("     ").append(i + 1).append(".").append(matchingTasks[i]).append("\n");
-            }
-        }
+        result.append(matchingTasks);
         return result.toString();
     }
 


### PR DESCRIPTION
When using the find command, the user can find
items even if the keyword matches the item only partially (eg. find boo will show matching task: "[T][] return book")